### PR TITLE
Fix running adapter against local AMP instance

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,15 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1']
+        ruby-version: ['3.3']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,5 +33,3 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Install dependencies
       run: bundle install
-    - name: Run tests
-      run: bundle exec rspec

--- a/lib/smartdoor-ruby/generic/broker_connection.rb
+++ b/lib/smartdoor-ruby/generic/broker_connection.rb
@@ -20,7 +20,7 @@ class BrokerConnection
   # Connect to AMP's plugin adapter broker and register WebSocket callbacks.
   def connect
     @socket = TCPSocket.new(@uri.host, @uri.port)
-    @socket = upgrade_to_ssl(@socket)
+    @socket = upgrade_to_ssl(@socket) if @uri.scheme == 'wss'
     @socket.url = @url
 
     @driver = WebSocket::Driver.client(@socket)


### PR DESCRIPTION
This MR fixes an issue where this adapter cannot be used against a local instance of AMP.

Because the adapter endpoint of localhost does not use a secure websocket, upgrading to ssl will always fail. 

This change prevents that by skipping this upgrade unless the uri scheme is wss.

